### PR TITLE
Require environment provided JWT secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # my_server
+
+## Environment configuration
+
+Before starting the application you **must** set a strong `JWT_SECRET` environment variable. The server loads this value on startup and will exit if it is missing to prevent running with an insecure default.
+
+Example (`.env` file):
+
+```
+JWT_SECRET="a-very-long-random-string-with-symbols-and-numbers"
+```
+
+Choose a high-entropy string (at least 32 characters mixing upper/lower case letters, numbers, and symbols) and keep it private.

--- a/config/secrets.js
+++ b/config/secrets.js
@@ -1,5 +1,12 @@
 // config/secrets.js
 require('dotenv').config();
+
+const { JWT_SECRET } = process.env;
+
+if (!JWT_SECRET) {
+  throw new Error('Missing JWT_SECRET environment variable. Set a strong secret before starting the server.');
+}
+
 module.exports = {
-  JWT_SECRET: process.env.JWT_SECRET || 'e-3!0OE3icN,TYmG'
+  JWT_SECRET
 };


### PR DESCRIPTION
## Summary
- stop falling back to a hard-coded JWT secret and require JWT_SECRET to be defined
- document the need for a strong JWT secret in the README so deployments configure it properly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e62a183344832ea041ea534d56a9eb