### PR TITLE
Add full profile customization tools

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -1,6 +1,52 @@
 const mongoose = require("mongoose");
 const bcrypt = require("bcrypt");
 
+const visibilityLevels = ["public", "followers", "private"];
+const defaultVisibilityScopes = {
+  posts: "public",
+  comments: "followers",
+  chats: "private",
+  badges: "public",
+  activity: "followers"
+};
+
+const badgeSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true, trim: true },
+    description: { type: String, default: "", trim: true },
+    icon: { type: String, default: "", trim: true },
+    earnedAt: { type: Date, default: Date.now }
+  },
+  { _id: false }
+);
+
+const activityEntrySchema = new mongoose.Schema(
+  {
+    type: {
+      type: String,
+      enum: ["post", "comment", "chat", "achievement", "system", "custom"],
+      default: "custom"
+    },
+    title: { type: String, required: true, trim: true },
+    detail: { type: String, default: "", trim: true },
+    link: { type: String, default: "", trim: true },
+    metadata: { type: mongoose.Schema.Types.Mixed, default: {} },
+    occurredAt: { type: Date, default: Date.now }
+  },
+  { _id: false }
+);
+
+const visibilityScopeSchema = new mongoose.Schema(
+  {
+    posts: { type: String, enum: visibilityLevels, default: "public" },
+    comments: { type: String, enum: visibilityLevels, default: "followers" },
+    chats: { type: String, enum: visibilityLevels, default: "private" },
+    badges: { type: String, enum: visibilityLevels, default: "public" },
+    activity: { type: String, enum: visibilityLevels, default: "followers" }
+  },
+  { _id: false }
+);
+
 // 권한별 기능 매핑 (참고)
 // 관리자 추가/삭제    superadmin       다른 관리자 관리(최고관리자만)
 // 사용자 삭제/정지/메모 user_manage     일반 사용자 계정 관리
@@ -31,6 +77,16 @@ const userSchema = new mongoose.Schema(
     intro: { type: String, default: "" },     // 자기소개
     photo: { type: String, default: "" },      // 프로필 사진 경로 (없으면 빈 문자열)
     email: { type: String, trim: true, lowercase: true, default: "" }, // 계정 연락용 이메일
+
+    backgroundImage: { type: String, default: "" },
+    statusMessage: { type: String, default: "" },
+    badges: { type: [badgeSchema], default: [] },
+    activityHistory: { type: [activityEntrySchema], default: [] },
+    profileVisibility: { type: String, enum: ["public", "private"], default: "public" },
+    visibilityScopes: {
+      type: visibilityScopeSchema,
+      default: () => ({ ...defaultVisibilityScopes })
+    },
 
     blockedUsers: {
       type: [mongoose.Schema.Types.ObjectId],

--- a/public/css/profile.css
+++ b/public/css/profile.css
@@ -1,170 +1,488 @@
-﻿/* profile.css */
-    body {
-      font-family: Arial, sans-serif;
-      background: #f5f5f5;
-      margin: 0;
-      padding: 0;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      min-height: 100vh;
-    }
+:root {
+  --profile-bg: #f3f4f6;
+  --profile-surface: #ffffff;
+  --profile-border: rgba(15, 23, 42, 0.08);
+  --profile-muted: #6b7280;
+  --profile-strong: #111827;
+  --profile-primary: #2563eb;
+  --profile-primary-dark: #1e40af;
+  --profile-accent: #f97316;
+  --profile-radius: 18px;
+  --profile-shadow: 0 22px 45px rgba(15, 23, 42, 0.18);
+  --profile-ghost: rgba(255, 255, 255, 0.72);
+}
 
-    main.profile-stage {
-      flex: 1;
-      width: 100%;
-      display: flex;
-      justify-content: center;
-      align-items: flex-start;
-      padding: 32px 16px 48px;
-      box-sizing: border-box;
-    }
+body.profile-page {
+  font-family: "Pretendard", "Noto Sans KR", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: linear-gradient(180deg, #e5ecff 0%, var(--profile-bg) 40%);
+  margin: 0;
+  color: var(--profile-strong);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
 
-    .profile-container {
-      background: white;
-      margin-top: 50px;
-      padding: 30px;
-      border-radius: 12px;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-      max-width: 500px;
-      width: 100%;
-      text-align: center;
-    }
+main.profile-stage {
+  width: min(1100px, 100% - 32px);
+  margin: 96px auto 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
 
-    .profile-item {
-      margin-bottom: 20px;
-      position: relative;
-    }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
 
-    .profile-item img {
-      width: 120px;
-      height: 120px;
-      border-radius: 50%;
-      object-fit: cover;
-      border: 3px solid #4CAF50;
-    }
+.profile-hero {
+  background: var(--profile-surface);
+  border-radius: var(--profile-radius);
+  box-shadow: var(--profile-shadow);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
 
-    .profile-name {
-      font-size: 24px;
-      font-weight: bold;
-    }
+.hero-background {
+  position: relative;
+  height: 220px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.85), rgba(249, 115, 22, 0.85));
+}
 
-    .profile-intro {
-      font-size: 16px;
-      color: #555;
-      line-height: 1.5;
-    }
+.hero-background img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: none;
+}
 
-    .edit-btn {
-      position: absolute;
-      right: 0;
-      top: 0;
-      cursor: pointer;
-      font-size: 16px;
-      background: none;
-      border: none;
-      color: #4CAF50;
-    }
+.hero-background.has-image img {
+  display: block;
+}
 
-    .edit-input {
-      font-size: 16px;
-      padding: 4px 8px;
-      width: 100%;
-      box-sizing: border-box;
-      border-radius: 4px;
-      border: 1px solid #ccc;
-    }
+.background-actions {
+  position: absolute;
+  right: 16px;
+  bottom: 16px;
+  display: flex;
+  gap: 10px;
+}
 
-    .save-btn {
-      margin-top: 10px;
-      padding: 6px 12px;
-      font-size: 14px;
-      cursor: pointer;
-      border-radius: 4px;
-      border: none;
-      background: #4CAF50;
-      color: white;
-    }
+.hero-body {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 32px;
+  padding: 32px 40px 40px;
+}
 
-    .save-btn:hover {
-      background: #45a049;
-    }
+.avatar-block {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  align-items: center;
+}
 
-    #profilePicInput {
-      display: none;
-    }
+.avatar-preview {
+  position: relative;
+  width: 168px;
+  height: 168px;
+  border-radius: 32px;
+  overflow: hidden;
+  box-shadow: 0 16px 35px rgba(30, 64, 175, 0.24);
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.4), rgba(59, 130, 246, 0.55));
+}
 
-    /* 활동 내역 탭 스타일 */
-    .activity-tabs {
-      display: flex;
-      border-bottom: 2px solid #eee;
-      margin-top: 40px;
-      margin-bottom: 20px;
-    }
-    .tab-button {
-      padding: 10px 20px;
-      cursor: pointer;
-      border: none;
-      background: none;
-      font-size: 16px;
-      font-weight: 500;
-      color: #888;
-      border-bottom: 2px solid transparent;
-    }
-    .tab-button.active {
-      color: #4CAF50;
-      border-bottom-color: #4CAF50;
-    }
-    .activity-content {
-      display: none;
-      text-align: left;
-    }
-    .activity-content.active {
-      display: block;
-    }
-    .activity-list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-    }
-    .activity-list li {
-      padding: 15px 10px;
-      border-bottom: 1px solid #f0f0f0;
-    }
-    .activity-list li:last-child {
-      border-bottom: none;
-    }
-    .activity-list a {
-      text-decoration: none;
-      color: #333;
-      font-weight: 500;
-    }
-    .activity-list a:hover {
-      color: #4CAF50;
-    }
-    .activity-list .meta {
-      font-size: 12px;
-      color: #888;
-      margin-top: 5px;
-    }
-    .activity-list .comment-content {
-      background-color: #f9f9f9;
-      padding: 8px;
-      border-radius: 4px;
-      margin-top: 8px;
-      font-style: italic;
-    }
+.avatar-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: none;
+}
 
-/* Toast notifications on profile page */
+.avatar-preview.has-image img {
+  display: block;
+}
+
+.avatar-placeholder {
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.65), rgba(255, 255, 255, 0));
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+  color: rgba(37, 99, 235, 0.6);
+}
+
+.avatar-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.profile-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  font-weight: 600;
+  color: var(--profile-strong);
+  font-size: 14px;
+}
+
+.field input,
+.field textarea,
+.field select {
+  border-radius: 12px;
+  border: 1px solid var(--profile-border);
+  padding: 12px 14px;
+  font-size: 15px;
+  font-family: inherit;
+  resize: vertical;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field textarea:focus,
+.field select:focus {
+  outline: none;
+  border-color: var(--profile-primary);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+}
+
+.primary-btn,
+.ghost-btn {
+  border-radius: 999px;
+  padding: 10px 18px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.primary-btn {
+  background: linear-gradient(135deg, var(--profile-primary), var(--profile-primary-dark));
+  color: #ffffff;
+  box-shadow: 0 10px 25px rgba(37, 99, 235, 0.35);
+}
+
+.primary-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 28px rgba(37, 99, 235, 0.35);
+}
+
+.ghost-btn {
+  background: var(--profile-ghost);
+  color: var(--profile-strong);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+.ghost-btn:hover {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.ghost-btn.ghost-danger {
+  color: #dc2626;
+  border-color: rgba(220, 38, 38, 0.2);
+}
+
+.control-card {
+  background: var(--profile-surface);
+  border-radius: var(--profile-radius);
+  box-shadow: var(--profile-shadow);
+  padding: 28px 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.control-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.control-header h2 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.control-description {
+  margin: 0;
+  color: var(--profile-muted);
+  font-size: 14px;
+}
+
+.visibility-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 24px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background-color: #d1d5db;
+  transition: 0.2s;
+  border-radius: 34px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 4px;
+  bottom: 3px;
+  background-color: white;
+  transition: 0.2s;
+  border-radius: 50%;
+}
+
+.switch input:checked + .slider {
+  background-color: var(--profile-primary);
+}
+
+.switch input:checked + .slider:before {
+  transform: translateX(22px);
+}
+
+.scope-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 18px;
+}
+
+.profile-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 16px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.section-heading p {
+  margin: 0;
+  color: var(--profile-muted);
+  font-size: 14px;
+}
+
+.badge-manager,
+.activity-feed,
+.recent-activity {
+  background: var(--profile-surface);
+  border-radius: var(--profile-radius);
+  box-shadow: var(--profile-shadow);
+  padding: 28px 32px;
+}
+
+.badge-list {
+  list-style: none;
+  margin: 0 0 16px;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.badge-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--profile-primary-dark);
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.badge-chip img {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.badge-chip button {
+  background: none;
+  border: none;
+  color: rgba(17, 24, 39, 0.55);
+  cursor: pointer;
+  padding: 0;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+}
+
+.badge-chip button:hover {
+  color: #dc2626;
+}
+
+.badge-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.field-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+
+.activity-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.activity-item {
+  padding: 16px;
+  border-radius: 16px;
+  background: rgba(37, 99, 235, 0.06);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  display: grid;
+  gap: 6px;
+}
+
+.activity-item strong {
+  font-size: 15px;
+}
+
+.activity-item span {
+  color: var(--profile-muted);
+  font-size: 13px;
+}
+
+.activity-item a {
+  color: var(--profile-primary);
+  font-size: 13px;
+  text-decoration: none;
+}
+
+.activity-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.recent-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.recent-card {
+  padding: 20px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.03);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.recent-card h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.recent-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.recent-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.recent-item a {
+  color: var(--profile-primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.recent-item time {
+  color: var(--profile-muted);
+  font-size: 12px;
+}
+
+.empty-state {
+  padding: 16px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.04);
+  color: var(--profile-muted);
+  font-size: 14px;
+  text-align: center;
+}
+
 .notification-popup {
   position: fixed;
-  top: 72px;
+  top: 90px;
   right: 24px;
   min-width: 240px;
-  padding: 14px 18px;
-  border-radius: 12px;
+  padding: 16px 20px;
+  border-radius: 16px;
   color: #ffffff;
-  background: #059669;
+  background: var(--profile-primary);
   box-shadow: 0 18px 35px rgba(15, 23, 42, 0.22);
   z-index: 4000;
   font-size: 14px;
@@ -198,12 +516,53 @@
   background: #2563eb;
 }
 
-@media (max-width: 540px) {
-  .notification-popup {
-    top: 88px;
-    right: 12px;
-    left: 12px;
-    min-width: 0;
+@media (max-width: 900px) {
+  .hero-body {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .avatar-actions {
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .profile-meta {
+    width: 100%;
+  }
+
+  .control-header {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }
 
+@media (max-width: 640px) {
+  main.profile-stage {
+    margin-top: 72px;
+    gap: 24px;
+  }
+
+  .profile-hero,
+  .badge-manager,
+  .activity-feed,
+  .recent-activity,
+  .control-card {
+    padding: 24px;
+  }
+
+  .hero-background {
+    height: 160px;
+  }
+
+  .avatar-preview {
+    width: 132px;
+    height: 132px;
+  }
+
+  .primary-btn,
+  .ghost-btn {
+    width: 100%;
+  }
+}

--- a/public/js/profile-page.js
+++ b/public/js/profile-page.js
@@ -1,0 +1,522 @@
+(() => {
+  const token = localStorage.getItem("token");
+  if (!token) {
+    window.location.href = "login.html";
+    return;
+  }
+
+  const elements = {
+    backgroundWrapper: document.getElementById("backgroundWrapper"),
+    backgroundPreview: document.getElementById("backgroundPreview"),
+    backgroundInput: document.getElementById("backgroundInput"),
+    backgroundUploadBtn: document.getElementById("backgroundUploadBtn"),
+    backgroundRemoveBtn: document.getElementById("backgroundRemoveBtn"),
+    avatarWrapper: document.getElementById("avatarWrapper"),
+    avatarPlaceholder: document.getElementById("avatarPlaceholder"),
+    profilePic: document.getElementById("profilePic"),
+    profilePicInput: document.getElementById("profilePicInput"),
+    avatarUploadBtn: document.getElementById("avatarUploadBtn"),
+    avatarRemoveBtn: document.getElementById("avatarRemoveBtn"),
+    displayName: document.getElementById("displayName"),
+    introInput: document.getElementById("introInput"),
+    statusMessageInput: document.getElementById("statusMessageInput"),
+    visibilityToggle: document.getElementById("visibilityToggle"),
+    scopePosts: document.getElementById("scopePosts"),
+    scopeComments: document.getElementById("scopeComments"),
+    scopeChats: document.getElementById("scopeChats"),
+    scopeBadges: document.getElementById("scopeBadges"),
+    scopeActivity: document.getElementById("scopeActivity"),
+    saveProfileBtn: document.getElementById("saveProfileBtn"),
+    badgeList: document.getElementById("badgeList"),
+    badgeForm: document.getElementById("badgeForm"),
+    badgeName: document.getElementById("badgeName"),
+    badgeIcon: document.getElementById("badgeIcon"),
+    badgeDescription: document.getElementById("badgeDescription"),
+    activityList: document.getElementById("activityList"),
+    activityForm: document.getElementById("activityForm"),
+    activityType: document.getElementById("activityType"),
+    activityTitle: document.getElementById("activityTitle"),
+    activityDetail: document.getElementById("activityDetail"),
+    activityLink: document.getElementById("activityLink"),
+    recentPosts: document.getElementById("recentPosts"),
+    recentComments: document.getElementById("recentComments"),
+    recentChats: document.getElementById("recentChats")
+  };
+
+  if (elements.avatarPlaceholder) {
+    elements.avatarPlaceholder.textContent = "🌟";
+  }
+
+  const state = {
+    badges: [],
+    activityHistory: []
+  };
+
+  const activityLabels = {
+    post: "게시글",
+    comment: "댓글",
+    chat: "채팅",
+    achievement: "업적",
+    system: "시스템",
+    custom: "활동"
+  };
+
+  function showToast(message, type = "success") {
+    const root = document.getElementById("toastRoot") || document.body;
+    const toast = document.createElement("div");
+    toast.className = `notification-popup ${type}`;
+    toast.textContent = message;
+    root.appendChild(toast);
+    requestAnimationFrame(() => {
+      toast.classList.add("show");
+    });
+    setTimeout(() => {
+      toast.classList.add("fade-out");
+      toast.addEventListener("transitionend", () => toast.remove(), { once: true });
+    }, 2600);
+  }
+
+  function formatDateTime(value) {
+    if (!value) return "";
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "";
+    return new Intl.DateTimeFormat("ko-KR", {
+      dateStyle: "medium",
+      timeStyle: "short"
+    }).format(date);
+  }
+
+  function updateAvatarPreview(photoPath) {
+    if (photoPath) {
+      elements.profilePic.src = photoPath;
+      elements.profilePic.style.display = "block";
+      elements.avatarWrapper.classList.add("has-image");
+      elements.avatarPlaceholder.style.display = "none";
+    } else {
+      elements.profilePic.removeAttribute("src");
+      elements.profilePic.style.display = "none";
+      elements.avatarWrapper.classList.remove("has-image");
+      elements.avatarPlaceholder.style.display = "flex";
+      elements.avatarPlaceholder.textContent = "🌟";
+    }
+  }
+
+  function updateBackgroundPreview(imagePath) {
+    if (imagePath) {
+      elements.backgroundPreview.src = imagePath;
+      elements.backgroundPreview.style.display = "block";
+      elements.backgroundWrapper.classList.add("has-image");
+    } else {
+      elements.backgroundPreview.removeAttribute("src");
+      elements.backgroundPreview.style.display = "none";
+      elements.backgroundWrapper.classList.remove("has-image");
+    }
+  }
+
+  function renderBadges() {
+    elements.badgeList.innerHTML = "";
+    if (!state.badges.length) {
+      const empty = document.createElement("li");
+      empty.className = "empty-state";
+      empty.textContent = "등록된 뱃지가 없습니다.";
+      elements.badgeList.appendChild(empty);
+      return;
+    }
+
+    state.badges.forEach((badge, index) => {
+      const item = document.createElement("li");
+      item.className = "badge-chip";
+      if (badge.icon) {
+        if (/^https?:\/\//i.test(badge.icon)) {
+          const img = document.createElement("img");
+          img.src = badge.icon;
+          img.alt = `${badge.name} 아이콘`;
+          item.appendChild(img);
+        } else {
+          const iconSpan = document.createElement("span");
+          iconSpan.textContent = badge.icon;
+          item.appendChild(iconSpan);
+        }
+      }
+      const label = document.createElement("span");
+      label.textContent = badge.name;
+      label.title = badge.description || "";
+      item.appendChild(label);
+
+      const removeBtn = document.createElement("button");
+      removeBtn.type = "button";
+      removeBtn.setAttribute("aria-label", `${badge.name} 뱃지 삭제`);
+      removeBtn.dataset.removeBadge = index.toString();
+      removeBtn.textContent = "×";
+      item.appendChild(removeBtn);
+
+      elements.badgeList.appendChild(item);
+    });
+  }
+
+  function renderActivity() {
+    elements.activityList.innerHTML = "";
+    if (!state.activityHistory.length) {
+      const empty = document.createElement("li");
+      empty.className = "empty-state";
+      empty.textContent = "기록된 활동이 없습니다.";
+      elements.activityList.appendChild(empty);
+      return;
+    }
+
+    state.activityHistory.forEach((entry) => {
+      const item = document.createElement("li");
+      item.className = "activity-item";
+
+      const header = document.createElement("span");
+      const typeLabel = activityLabels[entry.type] || activityLabels.custom;
+      header.textContent = `${typeLabel} • ${formatDateTime(entry.occurredAt)}`;
+      item.appendChild(header);
+
+      const title = document.createElement("strong");
+      title.textContent = entry.title;
+      item.appendChild(title);
+
+      if (entry.detail) {
+        const detail = document.createElement("span");
+        detail.textContent = entry.detail;
+        item.appendChild(detail);
+      }
+
+      if (entry.link) {
+        const anchor = document.createElement("a");
+        anchor.href = entry.link;
+        anchor.target = "_blank";
+        anchor.rel = "noopener";
+        anchor.textContent = "바로가기";
+        item.appendChild(anchor);
+      }
+
+      elements.activityList.appendChild(item);
+    });
+  }
+
+  function renderRecentList(container, items, emptyMessage, buildItem) {
+    container.innerHTML = "";
+    if (!items || !items.length) {
+      const empty = document.createElement("li");
+      empty.className = "empty-state";
+      empty.textContent = emptyMessage;
+      container.appendChild(empty);
+      return;
+    }
+
+    items.forEach((entry) => {
+      const node = buildItem(entry);
+      container.appendChild(node);
+    });
+  }
+
+  function buildRecentPost(post) {
+    const item = document.createElement("li");
+    item.className = "recent-item";
+
+    const link = document.createElement("a");
+    link.href = `/board.html?id=${post._id}`;
+    link.textContent = post.title || "제목 없음";
+    item.appendChild(link);
+
+    const meta = document.createElement("span");
+    const category = post.category || "카테고리 없음";
+    meta.textContent = `${category} • ${formatDateTime(post.time)}`;
+    item.appendChild(meta);
+
+    return item;
+  }
+
+  function buildRecentComment(comment) {
+    const item = document.createElement("li");
+    item.className = "recent-item";
+
+    const excerpt = document.createElement("div");
+    excerpt.textContent = comment.content || "내용 없음";
+    item.appendChild(excerpt);
+
+    const link = document.createElement("a");
+    link.href = `/board.html?id=${comment.postId}`;
+    link.textContent = `"${comment.postTitle || "게시글"}"으로 이동`;
+    item.appendChild(link);
+
+    const meta = document.createElement("time");
+    meta.dateTime = new Date(comment.time).toISOString();
+    meta.textContent = formatDateTime(comment.time);
+    item.appendChild(meta);
+
+    return item;
+  }
+
+  function buildRecentChat(chat) {
+    const item = document.createElement("li");
+    item.className = "recent-item";
+
+    const preview = document.createElement("div");
+    preview.textContent = chat.messageType === "image" ? "[이미지 메시지]" : chat.message;
+    item.appendChild(preview);
+
+    const meta = document.createElement("time");
+    meta.dateTime = new Date(chat.time).toISOString();
+    meta.textContent = `방 ${chat.room} • ${formatDateTime(chat.time)}`;
+    item.appendChild(meta);
+
+    return item;
+  }
+
+  async function loadOverview() {
+    try {
+      const res = await fetch("/api/profile/overview", {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      if (!res.ok) throw new Error("프로필 정보를 불러오지 못했습니다.");
+      const data = await res.json();
+
+      if (data.profile) {
+        elements.displayName.value = data.profile.name || data.profile.username || "";
+        elements.introInput.value = data.profile.intro || "";
+        elements.statusMessageInput.value = data.profile.statusMessage || "";
+        elements.visibilityToggle.checked = data.profile.profileVisibility !== "private";
+
+        const scopes = data.profile.visibilityScopes || {};
+        elements.scopePosts.value = scopes.posts || "public";
+        elements.scopeComments.value = scopes.comments || "followers";
+        elements.scopeChats.value = scopes.chats || "private";
+        elements.scopeBadges.value = scopes.badges || "public";
+        elements.scopeActivity.value = scopes.activity || "followers";
+
+        updateAvatarPreview(data.profile.photo);
+        updateBackgroundPreview(data.profile.backgroundImage);
+
+        state.badges = Array.isArray(data.profile.badges) ? [...data.profile.badges] : [];
+      }
+
+      state.activityHistory = Array.isArray(data.activityHistory)
+        ? [...data.activityHistory]
+        : Array.isArray(data.profile?.activityHistory)
+          ? [...data.profile.activityHistory]
+          : [];
+
+      renderBadges();
+      renderActivity();
+
+      renderRecentList(elements.recentPosts, data.recentPosts, "최근 게시글이 없습니다.", buildRecentPost);
+      renderRecentList(elements.recentComments, data.recentComments, "최근 댓글이 없습니다.", buildRecentComment);
+      renderRecentList(elements.recentChats, data.recentChats, "최근 채팅이 없습니다.", buildRecentChat);
+    } catch (error) {
+      console.error(error);
+      showToast("프로필 정보를 불러오지 못했습니다.", "error");
+    }
+  }
+
+  async function saveProfile() {
+    let success = true;
+    try {
+      const payload = {
+        name: elements.displayName.value.trim(),
+        intro: elements.introInput.value.trim(),
+        statusMessage: elements.statusMessageInput.value.trim(),
+        profileVisibility: elements.visibilityToggle.checked ? "public" : "private",
+        visibilityScopes: {
+          posts: elements.scopePosts.value,
+          comments: elements.scopeComments.value,
+          chats: elements.scopeChats.value,
+          badges: elements.scopeBadges.value,
+          activity: elements.scopeActivity.value
+        }
+      };
+
+      const res = await fetch("/api/profile", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) throw new Error("프로필 저장 실패");
+    } catch (error) {
+      success = false;
+      console.error(error);
+      showToast("프로필 정보를 저장하지 못했습니다.", "error");
+    }
+
+    try {
+      const res = await fetch("/api/profile/badges", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ badges: state.badges })
+      });
+      if (!res.ok) throw new Error("배지 저장 실패");
+    } catch (error) {
+      success = false;
+      console.error(error);
+      showToast("배지를 저장하지 못했습니다.", "error");
+    }
+
+    if (success) {
+      showToast("프로필이 저장되었습니다.");
+      loadOverview();
+    }
+  }
+
+  async function uploadAvatar(file) {
+    const formData = new FormData();
+    formData.append("photo", file);
+    try {
+      const res = await fetch("/api/profile/photo", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData
+      });
+      if (!res.ok) throw new Error("프로필 사진 업로드 실패");
+      const data = await res.json();
+      updateAvatarPreview(data.path);
+      showToast("프로필 사진이 업데이트되었습니다.");
+    } catch (error) {
+      console.error(error);
+      showToast("프로필 사진 업로드에 실패했습니다.", "error");
+    }
+  }
+
+  async function removeAvatar() {
+    try {
+      const res = await fetch("/api/profile/photo", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      if (!res.ok) throw new Error("프로필 사진 삭제 실패");
+      updateAvatarPreview("");
+      showToast("프로필 사진이 삭제되었습니다.", "info");
+    } catch (error) {
+      console.error(error);
+      showToast("프로필 사진을 삭제하지 못했습니다.", "error");
+    }
+  }
+
+  async function uploadBackground(file) {
+    const formData = new FormData();
+    formData.append("background", file);
+    try {
+      const res = await fetch("/api/profile/background", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+        body: formData
+      });
+      if (!res.ok) throw new Error("배경 이미지 업로드 실패");
+      const data = await res.json();
+      updateBackgroundPreview(data.path);
+      showToast("배경 이미지가 업데이트되었습니다.");
+    } catch (error) {
+      console.error(error);
+      showToast("배경 이미지를 업로드하지 못했습니다.", "error");
+    }
+  }
+
+  async function removeBackground() {
+    try {
+      const res = await fetch("/api/profile/background", {
+        method: "DELETE",
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      if (!res.ok) throw new Error("배경 이미지 삭제 실패");
+      updateBackgroundPreview("");
+      showToast("배경 이미지가 삭제되었습니다.", "info");
+    } catch (error) {
+      console.error(error);
+      showToast("배경 이미지를 삭제하지 못했습니다.", "error");
+    }
+  }
+
+  elements.badgeForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+    const name = elements.badgeName.value.trim();
+    if (!name) {
+      showToast("뱃지 이름을 입력해 주세요.", "warning");
+      return;
+    }
+
+    state.badges.push({
+      name,
+      icon: elements.badgeIcon.value.trim(),
+      description: elements.badgeDescription.value.trim(),
+      earnedAt: new Date().toISOString()
+    });
+
+    elements.badgeForm.reset();
+    renderBadges();
+  });
+
+  elements.badgeList.addEventListener("click", (event) => {
+    const target = event.target;
+    if (target instanceof HTMLButtonElement && target.dataset.removeBadge) {
+      const index = Number.parseInt(target.dataset.removeBadge, 10);
+      if (!Number.isNaN(index)) {
+        state.badges.splice(index, 1);
+        renderBadges();
+      }
+    }
+  });
+
+  elements.activityForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const payload = {
+      type: elements.activityType.value,
+      title: elements.activityTitle.value.trim(),
+      detail: elements.activityDetail.value.trim(),
+      link: elements.activityLink.value.trim()
+    };
+
+    if (!payload.title) {
+      showToast("활동 제목을 입력해 주세요.", "warning");
+      return;
+    }
+
+    try {
+      const res = await fetch("/api/profile/activity", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) throw new Error("활동 추가 실패");
+      const data = await res.json();
+      state.activityHistory = Array.isArray(data.activityHistory) ? data.activityHistory : [];
+      renderActivity();
+      elements.activityForm.reset();
+      showToast("활동이 추가되었습니다.");
+    } catch (error) {
+      console.error(error);
+      showToast("활동을 추가하지 못했습니다.", "error");
+    }
+  });
+
+  elements.saveProfileBtn.addEventListener("click", saveProfile);
+
+  elements.avatarUploadBtn.addEventListener("click", () => elements.profilePicInput.click());
+  elements.profilePicInput.addEventListener("change", (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    uploadAvatar(file);
+    event.target.value = "";
+  });
+  elements.avatarRemoveBtn.addEventListener("click", removeAvatar);
+
+  elements.backgroundUploadBtn.addEventListener("click", () => elements.backgroundInput.click());
+  elements.backgroundInput.addEventListener("change", (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    uploadBackground(file);
+    event.target.value = "";
+  });
+  elements.backgroundRemoveBtn.addEventListener("click", removeBackground);
+
+  loadOverview();
+})();

--- a/public/profile.html
+++ b/public/profile.html
@@ -1,4 +1,3 @@
-﻿<!-- public/profile.html -->
 <!DOCTYPE html>
 <html lang="ko">
 <head>
@@ -26,10 +25,10 @@
       <span class="logo-divider" aria-hidden="true"></span>
       <span class="logo-rest">OUT</span>
     </a>
-        <nav class="site-menu" aria-label="주요 메뉴">
+    <nav class="site-menu" aria-label="주요 메뉴">
       <a href="chat.html">채팅</a>
       <a href="posts.html">게시판</a>
-      <a href="profile.html">프로필</a>
+      <a href="profile.html" aria-current="page">프로필</a>
       <a href="inquiry.html">문의하기</a>
       <a href="setting.html">설정</a>
     </nav>
@@ -39,373 +38,190 @@
   </header>
 
   <main class="profile-stage">
-    <div class="profile-container">
-    <!-- 프로필 사진 -->
-    <div class="profile-item">
-      <span id="profilePicWrapper" style="display:inline-block; position:relative;">
-        <img id="profilePic" src="" alt="프로필 사진" style="display:none;">
-        <span id="defaultPic" style="display:inline-block;">
-          <!-- 귀여운 기본 SVG 아이콘 -->
-          <svg width="120" height="120" viewBox="0 0 120 120">
-            <circle cx="60" cy="60" r="60" fill="#e0e7ef"/>
-            <circle cx="60" cy="54" r="28" fill="#b6d0f7"/>
-            <ellipse cx="60" cy="98" rx="38" ry="22" fill="#b6d0f7"/>
-            <circle cx="60" cy="54" r="18" fill="#fff"/>
-            <ellipse cx="60" cy="98" rx="28" ry="14" fill="#fff"/>
-          </svg>
-        </span>
-      </span>
-      <button class="edit-btn" id="editPicBtn">✏️</button>
-      <button class="edit-btn" id="deletePicBtn" style="right:40px;">🗑️</button>
-      <button class="edit-btn" id="defaultPicBtn" style="right:80px;">🌱</button>
-      <input type="file" id="profilePicInput" accept=".jpg,.jpeg,.png,.gif">
-    </div>
-
-    <!-- 이름 -->
-    <div class="profile-item">
-      <div class="profile-name" id="profileName">사용자 이름</div>
-      <button class="edit-btn" id="editNameBtn">✏️</button>
-    </div>
-
-    <!-- 자기소개 -->
-    <div class="profile-item">
-      <div class="profile-intro" id="profileIntro">
-        안녕하세요! 여기에 자기소개를 작성할 수 있습니다.
+    <section class="profile-hero" aria-labelledby="profile-hero-heading">
+      <h1 id="profile-hero-heading" class="sr-only">프로필 커스터마이징</h1>
+      <div class="hero-background" id="backgroundWrapper">
+        <img id="backgroundPreview" alt="프로필 배경 이미지" />
+        <div class="background-actions">
+          <button type="button" id="backgroundUploadBtn" class="ghost-btn">배경 변경</button>
+          <button type="button" id="backgroundRemoveBtn" class="ghost-btn ghost-danger">배경 제거</button>
+          <input type="file" id="backgroundInput" accept="image/*" hidden>
+        </div>
       </div>
-      <button class="edit-btn" id="editIntroBtn">✏️</button>
-    </div>
+      <div class="hero-body">
+        <div class="avatar-block">
+          <div class="avatar-preview" id="avatarWrapper">
+            <img id="profilePic" alt="프로필 사진" />
+            <div class="avatar-placeholder" id="avatarPlaceholder" aria-hidden="true"></div>
+          </div>
+          <div class="avatar-actions">
+            <button type="button" id="avatarUploadBtn" class="primary-btn">사진 변경</button>
+            <button type="button" id="avatarRemoveBtn" class="ghost-btn">사진 제거</button>
+            <input type="file" id="profilePicInput" accept="image/*" hidden>
+          </div>
+        </div>
+        <div class="profile-meta">
+          <label class="field">
+            <span class="field-label">표시 이름</span>
+            <input id="displayName" type="text" maxlength="40" placeholder="이름 없음" autocomplete="off">
+          </label>
+          <label class="field">
+            <span class="field-label">소개</span>
+            <textarea id="introInput" rows="3" placeholder="자기소개를 입력해 주세요"></textarea>
+          </label>
+          <label class="field">
+            <span class="field-label">상태 메시지</span>
+            <textarea id="statusMessageInput" rows="2" placeholder="오늘의 기분은 어떤가요?"></textarea>
+          </label>
+        </div>
+      </div>
+    </section>
 
-    <button class="save-btn" id="saveProfileBtn">저장</button>
+    <section class="profile-controls" aria-labelledby="profile-privacy-heading">
+      <div class="control-card">
+        <div class="control-header">
+          <h2 id="profile-privacy-heading">공개 설정</h2>
+          <div class="visibility-toggle">
+            <span>비공개</span>
+            <label class="switch">
+              <input type="checkbox" id="visibilityToggle" aria-describedby="visibilityHelp">
+              <span class="slider"></span>
+            </label>
+            <span>공개</span>
+          </div>
+        </div>
+        <p id="visibilityHelp" class="control-description">공개로 전환하면 누구나 프로필을 볼 수 있습니다.</p>
+        <div class="scope-grid">
+          <label class="field">
+            <span class="field-label">게시글 공개 범위</span>
+            <select id="scopePosts">
+              <option value="public">전체 공개</option>
+              <option value="followers">팔로워만</option>
+              <option value="private">나만 보기</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field-label">댓글 공개 범위</span>
+            <select id="scopeComments">
+              <option value="public">전체 공개</option>
+              <option value="followers">팔로워만</option>
+              <option value="private">나만 보기</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field-label">채팅 공개 범위</span>
+            <select id="scopeChats">
+              <option value="public">전체 공개</option>
+              <option value="followers">팔로워만</option>
+              <option value="private">나만 보기</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field-label">배지 공개 범위</span>
+            <select id="scopeBadges">
+              <option value="public">전체 공개</option>
+              <option value="followers">팔로워만</option>
+              <option value="private">나만 보기</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field-label">활동 이력 공개 범위</span>
+            <select id="scopeActivity">
+              <option value="public">전체 공개</option>
+              <option value="followers">팔로워만</option>
+              <option value="private">나만 보기</option>
+            </select>
+          </label>
+        </div>
+      </div>
+      <button type="button" class="primary-btn" id="saveProfileBtn">변경 사항 저장</button>
+    </section>
 
-    <!-- 활동 내역 탭 -->
-    <div class="activity-tabs">
-      <button class="tab-button active" data-tab="my-posts">내 게시글</button>
-      <button class="tab-button" data-tab="my-comments">내 댓글</button>
-    </div>
+    <section class="badge-manager" aria-labelledby="badge-manager-heading">
+      <div class="section-heading">
+        <h2 id="badge-manager-heading">보유 뱃지</h2>
+        <p>보여주고 싶은 뱃지를 추가하거나 순서를 정리하세요.</p>
+      </div>
+      <ul id="badgeList" class="badge-list" aria-live="polite"></ul>
+      <form id="badgeForm" class="badge-form">
+        <div class="field-row">
+          <label class="field">
+            <span class="field-label">뱃지 이름</span>
+            <input type="text" id="badgeName" required maxlength="30" placeholder="예: 열정 가득" autocomplete="off">
+          </label>
+          <label class="field">
+            <span class="field-label">아이콘 (이모지 또는 URL)</span>
+            <input type="text" id="badgeIcon" maxlength="120" placeholder="예: 🔥 또는 https://" autocomplete="off">
+          </label>
+        </div>
+        <label class="field">
+          <span class="field-label">설명</span>
+          <input type="text" id="badgeDescription" maxlength="80" placeholder="뱃지 설명을 입력해 주세요" autocomplete="off">
+        </label>
+        <button type="submit" class="primary-btn">뱃지 추가</button>
+      </form>
+    </section>
 
-    <!-- 활동 내역 컨텐츠 -->
-    <div id="my-posts" class="activity-content active">
-      <ul id="myPostsList" class="activity-list">
-        <!-- 내 게시글 목록이 여기에 표시됩니다. -->
-      </ul>
-    </div>
-    <div id="my-comments" class="activity-content">
-      <ul id="myCommentsList" class="activity-list">
-        <!-- 내 댓글 목록이 여기에 표시됩니다. -->
-      </ul>
-    </div>
+    <section class="activity-feed" aria-labelledby="activity-feed-heading">
+      <div class="section-heading">
+        <h2 id="activity-feed-heading">활동 타임라인</h2>
+        <p>중요한 활동을 직접 추가하거나 자동 수집된 정보를 확인하세요.</p>
+      </div>
+      <ul id="activityList" class="activity-list" aria-live="polite"></ul>
+      <form id="activityForm" class="activity-form">
+        <div class="field-row">
+          <label class="field">
+            <span class="field-label">유형</span>
+            <select id="activityType">
+              <option value="achievement">업적</option>
+              <option value="post">게시글</option>
+              <option value="comment">댓글</option>
+              <option value="chat">채팅</option>
+              <option value="system">시스템</option>
+              <option value="custom">직접 입력</option>
+            </select>
+          </label>
+          <label class="field">
+            <span class="field-label">제목</span>
+            <input type="text" id="activityTitle" maxlength="60" required placeholder="활동 제목">
+          </label>
+        </div>
+        <label class="field">
+          <span class="field-label">설명</span>
+          <textarea id="activityDetail" rows="2" placeholder="세부 설명"></textarea>
+        </label>
+        <label class="field">
+          <span class="field-label">연결 링크 (선택)</span>
+          <input type="url" id="activityLink" placeholder="https://">
+        </label>
+        <button type="submit" class="ghost-btn">활동 추가</button>
+      </form>
+    </section>
 
-  </div>
-
-  <script>
-    const token = localStorage.getItem("token");
-    if (!token) {
-      window.location.href = "login.html";
-    }
-
-    const profilePic = document.getElementById("profilePic");
-    const profileName = document.getElementById("profileName");
-    const profileIntro = document.getElementById("profileIntro");
-    const editPicBtn = document.getElementById("editPicBtn");
-    const editNameBtn = document.getElementById("editNameBtn");
-    const editIntroBtn = document.getElementById("editIntroBtn");
-    const profilePicInput = document.getElementById("profilePicInput");
-    const saveBtn = document.getElementById("saveProfileBtn");
-    const deletePicBtn = document.getElementById("deletePicBtn");
-    const defaultPicBtn = document.getElementById("defaultPicBtn");
-
-    // 활동 내역 관련 요소
-    const tabsContainer = document.querySelector(".activity-tabs");
-    const contents = document.querySelectorAll(".activity-content");
-    const myPostsList = document.getElementById("myPostsList");
-    const myCommentsList = document.getElementById("myCommentsList");
-
-    let editedName = false;
-    let editedIntro = false;
-    let selectedPicFile = null;
-    let deletePhotoFlag = false; // 기본 이미지를 사용할지 여부
-
-    function showToast(message, type = 'success') {
-      const existing = document.querySelectorAll('.notification-popup');
-      existing.forEach((node) => node.remove());
-
-      const toast = document.createElement('div');
-      toast.className = `notification-popup ${type}`;
-      toast.textContent = message;
-      document.body.appendChild(toast);
-
-      requestAnimationFrame(() => {
-        toast.classList.add('show');
-      });
-
-      setTimeout(() => {
-        toast.classList.add('fade-out');
-        toast.addEventListener('transitionend', () => toast.remove(), { once: true });
-      }, 2600);
-    }
-
-
-    // 프로필 정보 불러오기
-    async function loadProfile() {
-      try {
-        const res = await fetch("/api/profile", {
-          headers: { "Authorization": "Bearer " + token }
-        });
-        if (!res.ok) throw new Error("프로필 불러오기 실패");
-        const data = await res.json();
-        if (data.photo) {
-          profilePic.src = data.photo;
-          profilePic.style.display = "";
-          document.getElementById("defaultPic").style.display = "none";
-        } else {
-          profilePic.src = "";
-          profilePic.style.display = "none";
-          document.getElementById("defaultPic").style.display = "";
-        }
-        profileName.textContent = data.name || data.username || "이름 없음";
-        profileIntro.textContent = data.intro || "자기소개가 없습니다.";
-      } catch {
-        showToast('프로필 정보를 불러오지 못했습니다.', 'error');
-      }
-    }
-    loadProfile();
-    loadMyPosts(); // 페이지 로드 시 내 게시글 로드
-
-    // 탭 클릭 이벤트
-    tabsContainer.addEventListener("click", (e) => {
-      if (e.target.tagName !== 'BUTTON') return;
-
-      const targetTab = e.target.dataset.tab;
-
-      tabsContainer.querySelectorAll('.tab-button').forEach(btn => btn.classList.remove('active'));
-      e.target.classList.add('active');
-
-      contents.forEach(content => {
-        content.classList.remove('active');
-        if (content.id === targetTab) {
-          content.classList.add('active');
-        }
-      });
-
-      if (targetTab === 'my-posts') {
-        loadMyPosts();
-      } else if (targetTab === 'my-comments') {
-        loadMyComments();
-      }
-    });
-
-    // 내 게시글 로드 함수
-    async function loadMyPosts() {
-      try {
-        // API 경로를 /api/profile/posts 로 수정합니다.
-        const res = await fetch("/api/profile/posts", { headers: { "Authorization": "Bearer " + token } });
-        if (!res.ok) throw new Error("게시글 목록 로드 실패");
-        const posts = await res.json();
-        myPostsList.innerHTML = "";
-        if (posts.length === 0) {
-          myPostsList.innerHTML = "<li>작성한 게시글이 없습니다.</li>";
-          return;
-        }
-        posts.forEach(post => {
-          const li = document.createElement('li');
-          li.innerHTML = `
-            <a href="/board.html?id=${post._id}">${post.title}</a>
-            <div class="meta">${new Date(post.time).toLocaleDateString()} | ${post.category}</div>
-          `;
-          myPostsList.appendChild(li);
-        });
-      } catch (err) {
-        myPostsList.innerHTML = `<li>게시글을 불러오는 중 오류가 발생했습니다.</li>`;
-      }
-    }
-
-    // 내 댓글 로드 함수
-    async function loadMyComments() {
-      try {
-        // API 경로를 /api/profile/comments 로 수정합니다.
-        const res = await fetch("/api/profile/comments", { headers: { "Authorization": "Bearer " + token } });
-        if (!res.ok) throw new Error("댓글 목록 로드 실패");
-        const comments = await res.json();
-        myCommentsList.innerHTML = "";
-        if (comments.length === 0) {
-          myCommentsList.innerHTML = "<li>작성한 댓글이 없습니다.</li>";
-          return;
-        }
-        comments.forEach(comment => {
-          const li = document.createElement('li');
-          li.innerHTML = `
-            <div class="comment-content">"${comment.content}"</div>
-            <a href="/board.html?id=${comment.postId}">└ "${comment.postTitle}" 글에서</a>
-            <div class="meta">${new Date(comment.time).toLocaleString()}</div>
-          `;
-          myCommentsList.appendChild(li);
-        });
-      } catch (err) {
-        myCommentsList.innerHTML = `<li>댓글을 불러오는 중 오류가 발생했습니다.</li>`;
-      }
-    }
-
-    // 사진 수정
-    editPicBtn.addEventListener("click", () => {
-      profilePicInput.click();
-    });
-    profilePicInput.addEventListener("change", (event) => {
-      const file = event.target.files[0];
-      if (!file) return;
-      const validTypes = ["image/jpeg", "image/png", "image/gif"];
-      if (!validTypes.includes(file.type)) {
-        showToast('이미지 파일만 업로드 가능합니다!', 'warning');
-        return;
-      }
-      // 미리보기
-      const reader = new FileReader();
-      reader.onload = () => {
-        profilePic.src = reader.result;
-        profilePic.style.display = "";
-        document.getElementById("defaultPic").style.display = "none";
-      };
-      reader.readAsDataURL(file);
-      selectedPicFile = file;
-      deletePhotoFlag = false; // 새 파일을 선택했으므로, 삭제 플래그는 해제합니다.
-    });
-
-    // 이름 수정
-    editNameBtn.addEventListener("click", () => {
-      if (!editedName) {
-        const input = document.createElement("input");
-        input.type = "text";
-        input.value = profileName.textContent;
-        input.className = "edit-input";
-        profileName.replaceWith(input);
-        editedName = input;
-      }
-    });
-
-    // 자기소개 수정
-    editIntroBtn.addEventListener("click", () => {
-      if (!editedIntro) {
-        const textarea = document.createElement("textarea");
-        textarea.className = "edit-input";
-        textarea.style.height = "60px";
-        textarea.value = profileIntro.textContent;
-        profileIntro.replaceWith(textarea);
-        editedIntro = textarea;
-      }
-    });
-
-    // 사진 삭제
-    deletePicBtn.addEventListener("click", async () => {
-      if (!confirm("프로필 사진을 삭제하시겠습니까?")) return;
-      try {
-        const res = await fetch("/api/profile/photo", {
-          method: "DELETE",
-          headers: { "Authorization": "Bearer " + token }
-        });
-        if (!res.ok) throw new Error("삭제 실패");
-        profilePic.src = "default-profile.png";
-        showToast('프로필 사진이 삭제되었습니다.', 'success');
-      } catch {
-        showToast('프로필 사진 삭제에 실패했습니다.', 'error');
-      }
-    });
-
-    // 기본 이미지로 변경
-    defaultPicBtn.addEventListener("click", () => {
-      profilePic.src = "";
-      profilePic.style.display = "none";
-      document.getElementById("defaultPic").style.display = "";
-      selectedPicFile = null;
-      deletePhotoFlag = true; // 기본 이미지로 변경했으므로, 삭제 플래그를 설정합니다.
-    });
-
-    // 저장 버튼
-    saveBtn.addEventListener("click", async () => {
-      let isSuccess = true; // 전체 저장 성공 여부
-      // 이름/소개 수정
-      let name = editedName ? editedName.value : profileName.textContent;
-      let intro = editedIntro ? editedIntro.value : profileIntro.textContent;
-      try {
-        const res = await fetch("/api/profile", {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-            "Authorization": "Bearer " + token
-          },
-          body: JSON.stringify({ name, intro })
-        });
-        if (!res.ok) throw new Error("프로필 수정 실패");
-      } catch {
-        showToast('프로필 수정에 실패했습니다.', 'error');
-        isSuccess = false;
-      }
-      // 이름/소개 화면에 반영
-      if (editedName) {
-        const div = document.createElement("div");
-        div.className = "profile-name";
-        div.id = "profileName";
-        div.textContent = editedName.value;
-        editedName.replaceWith(div);
-        editedName = false;
-      }
-      if (editedIntro) {
-        const div = document.createElement("div");
-        div.className = "profile-intro";
-        div.id = "profileIntro";
-        div.textContent = editedIntro.value;
-        editedIntro.replaceWith(div);
-        editedIntro = false;
-      }
-
-      // 사진 업로드 로직
-      if (selectedPicFile) {
-        const formData = new FormData();
-        formData.append("photo", selectedPicFile);
-        try {
-          const res = await fetch("/api/profile/photo", {
-            method: "POST",
-            headers: { "Authorization": "Bearer " + token },
-            body: formData
-          });
-          if (!res.ok) throw new Error("사진 업로드 실패");
-          const data = await res.json();
-          profilePic.src = data.path; // 서버로부터 받은 새 경로로 업데이트
-        } catch {
-          showToast('사진 업로드에 실패했습니다.', 'error');
-          isSuccess = false;
-        }
-        selectedPicFile = null;
-      } 
-      // 기본 프로필로 변경(사진 삭제) 로직 추가
-      else if (deletePhotoFlag) {
-        try {
-          const res = await fetch("/api/profile/photo", {
-            method: "DELETE",
-            headers: { "Authorization": "Bearer " + token }
-          });
-          if (!res.ok) throw new Error("사진 삭제 실패");
-        } catch {
-          showToast('프로필 사진 삭제에 실패했습니다.', 'error');
-          isSuccess = false;
-        }
-      }
-
-      deletePhotoFlag = false; // 작업 완료 후 플래그 초기화
-
-      if(isSuccess) {
-        showToast('프로필이 저장되었습니다!', 'success');
-        loadProfile(); // 저장 후 프로필 정보를 다시 불러와서 최종 상태를 확인
-      }
-    });
-  </script>
+    <section class="recent-activity" aria-labelledby="recent-activity-heading">
+      <div class="section-heading">
+        <h2 id="recent-activity-heading">최근 활동</h2>
+        <p>프로필에서 바로 최근 게시글, 댓글, 채팅을 확인할 수 있습니다.</p>
+      </div>
+      <div class="recent-grid">
+        <article class="recent-card" aria-labelledby="recent-posts-heading">
+          <h3 id="recent-posts-heading">최근 게시글</h3>
+          <ul id="recentPosts" class="recent-list"></ul>
+        </article>
+        <article class="recent-card" aria-labelledby="recent-comments-heading">
+          <h3 id="recent-comments-heading">최근 댓글</h3>
+          <ul id="recentComments" class="recent-list"></ul>
+        </article>
+        <article class="recent-card" aria-labelledby="recent-chats-heading">
+          <h3 id="recent-chats-heading">최근 채팅</h3>
+          <ul id="recentChats" class="recent-list"></ul>
+        </article>
+      </div>
+    </section>
   </main>
-  <script defer src="js/auth-helper.js"></script>
-  <script src="/socket.io/socket.io.js"></script>
-  <script defer src="js/notifications.js"></script>
-  <script defer src="js/profile-menu.js"></script>
-  <script defer src="js/pwa.js"></script>
-  <script defer src="js/topbar-dock.js"></script>
+
+  <div id="toastRoot"></div>
+
+  <script defer src="js/profile-page.js"></script>
 </body>
 </html>
-
-
-

--- a/routes/profile.js
+++ b/routes/profile.js
@@ -4,113 +4,423 @@ const multer = require("multer");
 const path = require("path");
 const fs = require("fs");
 const jwt = require("jsonwebtoken");
+const mongoose = require("mongoose");
+
 const User = require("../models/user");
-const Post = require("../models/post"); // Post 모델을 불러옵니다.
+const Post = require("../models/post");
+const Message = require("../models/message");
 const { JWT_SECRET } = require("../config/secrets");
+const logger = require("../config/logger");
 
 const photoDir = path.join(__dirname, "..", "uploads", "users");
+const backgroundDir = path.join(__dirname, "..", "uploads", "users", "backgrounds");
 const backupDir = path.join(__dirname, "..", "uploads", "archive", "profile_backup");
-[photoDir, backupDir].forEach(d=>{ if(!fs.existsSync(d)) fs.mkdirSync(d,{recursive:true}); });
+[photoDir, backgroundDir, backupDir].forEach((dirPath) => {
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+});
 
-function authSimple(req,res,next){
+const allowedImageExtensions = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp"]);
+const visibilityLevels = ["public", "followers", "private"];
+const activityTypes = ["post", "comment", "chat", "achievement", "system", "custom"];
+const visibilityKeys = ["posts", "comments", "chats", "badges", "activity"];
+
+function authSimple(req, res, next) {
   const token = req.headers.authorization?.split(" ")[1];
-  if(!token) return res.status(401).json({error:"토큰 없음"});
-  try { req.user = jwt.verify(token, JWT_SECRET); next(); }
-  catch { return res.status(401).json({error:"유효하지 않은 토큰"}); }
+  if (!token) {
+    return res.status(401).json({ error: "토큰 없음" });
+  }
+
+  try {
+    req.user = jwt.verify(token, JWT_SECRET);
+    next();
+  } catch (error) {
+    return res.status(401).json({ error: "유효하지 않은 토큰" });
+  }
 }
 
-// Multer 스토리지 설정 (파일 이름 생성 방식 수정)
-const storage = multer.diskStorage({
-  destination:(_,__,cb)=>cb(null, photoDir),
-  filename: (req, file, cb) => {
-    // 파일 이름이 겹치지 않도록 타임스탬프와 랜덤 문자열을 사용합니다.
-    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);
-    const extension = path.extname(file.originalname).toLowerCase(); // 확장자를 소문자로 통일
-    cb(null, `${req.user.username}-${uniqueSuffix}${extension}`);
+function imageFilter(_, file, cb) {
+  const extension = path.extname(file.originalname).toLowerCase();
+  if (allowedImageExtensions.has(extension)) {
+    cb(null, true);
+  } else {
+    cb(new Error("이미지 파일만 업로드 가능합니다."));
   }
+}
+
+function uniqueFileName(username, originalName) {
+  const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
+  const extension = path.extname(originalName).toLowerCase();
+  return `${username}-${uniqueSuffix}${extension}`;
+}
+
+const avatarStorage = multer.diskStorage({
+  destination: (_, __, cb) => cb(null, photoDir),
+  filename: (req, file, cb) => cb(null, uniqueFileName(req.user.username, file.originalname))
 });
 
-const upload = multer({
-  storage,
-  fileFilter:(_,file,cb)=>{
-    const ex = path.extname(file.originalname).toLowerCase();
-    cb(['.jpg','.jpeg','.png','.gif','.webp'].includes(ex)?null:new Error('이미지 파일만'), true);
-  }
+const backgroundStorage = multer.diskStorage({
+  destination: (_, __, cb) => cb(null, backgroundDir),
+  filename: (req, file, cb) => cb(null, uniqueFileName(req.user.username, file.originalname))
 });
 
-// 프로필 정보 조회 API
+const uploadAvatar = multer({ storage: avatarStorage, fileFilter: imageFilter });
+const uploadBackground = multer({ storage: backgroundStorage, fileFilter: imageFilter });
+
+function sanitizeVisibilityScopes(scopes) {
+  if (!scopes || typeof scopes !== "object") {
+    return undefined;
+  }
+
+  const sanitized = {};
+  for (const key of visibilityKeys) {
+    const value = scopes[key];
+    if (typeof value === "string" && visibilityLevels.includes(value)) {
+      sanitized[key] = value;
+    }
+  }
+
+  return Object.keys(sanitized).length ? sanitized : undefined;
+}
+
+function sanitizeBadges(badges) {
+  if (!Array.isArray(badges)) {
+    return null;
+  }
+
+  const sanitized = [];
+  for (const badge of badges) {
+    if (!badge || typeof badge.name !== "string") continue;
+    const name = badge.name.trim();
+    if (!name) continue;
+
+    let earnedAt = new Date();
+    if (badge.earnedAt) {
+      const parsed = new Date(badge.earnedAt);
+      if (!Number.isNaN(parsed.getTime())) {
+        earnedAt = parsed;
+      }
+    }
+
+    sanitized.push({
+      name,
+      description: typeof badge.description === "string" ? badge.description.trim() : "",
+      icon: typeof badge.icon === "string" ? badge.icon.trim() : "",
+      earnedAt
+    });
+  }
+
+  return sanitized;
+}
+
+function buildActivityEntry(body) {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+
+  const title = typeof body.title === "string" ? body.title.trim() : "";
+  if (!title) {
+    return null;
+  }
+
+  const type = activityTypes.includes(body.type) ? body.type : "custom";
+  const entry = {
+    type,
+    title,
+    detail: typeof body.detail === "string" ? body.detail.trim() : "",
+    link: typeof body.link === "string" ? body.link.trim() : "",
+    metadata: typeof body.metadata === "object" && body.metadata !== null ? body.metadata : {}
+  };
+
+  if (body.occurredAt) {
+    const occurredAt = new Date(body.occurredAt);
+    if (!Number.isNaN(occurredAt.getTime())) {
+      entry.occurredAt = occurredAt;
+    }
+  }
+
+  if (!entry.occurredAt) {
+    entry.occurredAt = new Date();
+  }
+
+  return entry;
+}
+
+function formatUserResponse(user) {
+  if (!user) {
+    return null;
+  }
+
+  return {
+    id: user._id,
+    username: user.username,
+    name: user.name,
+    intro: user.intro,
+    photo: user.photo,
+    backgroundImage: user.backgroundImage,
+    statusMessage: user.statusMessage,
+    badges: user.badges || [],
+    activityHistory: user.activityHistory || [],
+    profileVisibility: user.profileVisibility,
+    visibilityScopes: user.visibilityScopes
+  };
+}
+
 router.get("/", authSimple, async (req, res) => {
   try {
-    const user = await User.findById(req.user.id).select('-password'); // 비밀번호 제외
+    const user = await User.findById(req.user.id).select("-password");
     if (!user) {
       return res.status(404).json({ error: "사용자를 찾을 수 없습니다." });
     }
-    res.json(user);
-  } catch (err) {
+
+    res.json(formatUserResponse(user));
+  } catch (error) {
+    logger.error("Profile fetch failed", error);
     res.status(500).json({ error: "서버 오류가 발생했습니다." });
   }
 });
 
-// 프로필 정보(이름, 자기소개) 수정 API (로그 추가)
 router.put("/", authSimple, async (req, res) => {
   try {
-    const { name, intro } = req.body;
-    const oldUser = await User.findById(req.user.id).select('name intro');
-    
-    const user = await User.findByIdAndUpdate(
-      req.user.id,
-      { $set: { name, intro } },
-      { new: true, runValidators: true }
-    ).select('-password');
+    const { name, intro, statusMessage, profileVisibility, visibilityScopes } = req.body;
 
-    if (!user) {
+    const oldUser = await User.findById(req.user.id).select(
+      "name intro statusMessage profileVisibility visibilityScopes"
+    );
+
+    if (!oldUser) {
       return res.status(404).json({ error: "사용자를 찾을 수 없습니다." });
     }
-    
-    // 변경사항 로깅
-    const changes = [];
-    if (oldUser.name !== name) changes.push(`이름: ${oldUser.name} -> ${name}`);
-    if (oldUser.intro !== intro) changes.push(`소개: ${oldUser.intro || '없음'} -> ${intro || '없음'}`);
-    
-    if (changes.length > 0) {
-      const logger = require('../config/logger');
-      logger.info(`Profile updated: ${req.user.username} -> ${changes.join(', ')}`);
-      if (req.userLogger) req.userLogger('info', `프로필 정보 수정: ${changes.join(', ')}`);
+
+    const updates = {};
+
+    if (typeof name === "string") {
+      updates.name = name.trim();
     }
-    
-    res.json({ message: "프로필이 업데이트되었습니다.", user });
-  } catch (err) {
+    if (typeof intro === "string") {
+      updates.intro = intro.trim();
+    }
+    if (typeof statusMessage === "string") {
+      updates.statusMessage = statusMessage.trim();
+    }
+    if (typeof profileVisibility === "string" && ["public", "private"].includes(profileVisibility)) {
+      updates.profileVisibility = profileVisibility;
+    }
+
+    const sanitizedScopes = sanitizeVisibilityScopes(visibilityScopes);
+    if (sanitizedScopes) {
+      const existingScopes = oldUser.visibilityScopes
+        ? oldUser.visibilityScopes.toObject()
+        : {};
+      updates.visibilityScopes = { ...existingScopes, ...sanitizedScopes };
+    }
+
+    if (!Object.keys(updates).length) {
+      return res.json({ message: "변경할 프로필 정보가 없습니다.", user: formatUserResponse(oldUser) });
+    }
+
+    const user = await User.findByIdAndUpdate(
+      req.user.id,
+      { $set: updates },
+      { new: true, runValidators: true }
+    ).select("-password");
+
+    const changes = [];
+    if (updates.name !== undefined && oldUser.name !== updates.name) {
+      changes.push(`이름: ${oldUser.name || "(없음)"} -> ${updates.name || "(없음)"}`);
+    }
+    if (updates.intro !== undefined && oldUser.intro !== updates.intro) {
+      changes.push(`소개: ${oldUser.intro || "(없음)"} -> ${updates.intro || "(없음)"}`);
+    }
+    if (updates.statusMessage !== undefined && oldUser.statusMessage !== updates.statusMessage) {
+      changes.push(`상태 메시지 변경`);
+    }
+    if (updates.profileVisibility && oldUser.profileVisibility !== updates.profileVisibility) {
+      changes.push(`공개 범위: ${oldUser.profileVisibility} -> ${updates.profileVisibility}`);
+    }
+    if (updates.visibilityScopes) {
+      changes.push("세부 공개 범위 조정");
+    }
+
+    if (changes.length) {
+      logger.info(`Profile updated: ${req.user.username} -> ${changes.join(", ")}`);
+      if (req.userLogger) {
+        req.userLogger("info", `프로필 정보 수정: ${changes.join(", ")}`);
+      }
+    }
+
+    res.json({ message: "프로필이 업데이트되었습니다.", user: formatUserResponse(user) });
+  } catch (error) {
+    logger.error("Profile update failed", error);
     res.status(500).json({ error: "프로필 업데이트 중 오류가 발생했습니다." });
   }
 });
 
-// --- 내 활동 내역 API 추가 ---
+router.put("/badges", authSimple, async (req, res) => {
+  try {
+    const sanitized = sanitizeBadges(req.body.badges);
+    if (!sanitized) {
+      return res.status(400).json({ error: "배지를 배열 형태로 전달해주세요." });
+    }
 
-// 현재 로그인한 사용자가 작성한 게시글 목록 조회
+    const user = await User.findByIdAndUpdate(
+      req.user.id,
+      { $set: { badges: sanitized } },
+      { new: true, runValidators: true }
+    ).select("badges");
+
+    if (!user) {
+      return res.status(404).json({ error: "사용자를 찾을 수 없습니다." });
+    }
+
+    logger.info(`Profile badges updated: ${req.user.username} -> ${sanitized.length} badges`);
+    if (req.userLogger) {
+      req.userLogger("info", `배지 업데이트 (${sanitized.length}개)`);
+    }
+
+    res.json({ message: "배지가 업데이트되었습니다.", badges: user.badges });
+  } catch (error) {
+    logger.error("Badge update failed", error);
+    res.status(500).json({ error: "배지를 업데이트하는 중 오류가 발생했습니다." });
+  }
+});
+
+router.post("/activity", authSimple, async (req, res) => {
+  try {
+    const entry = buildActivityEntry(req.body);
+    if (!entry) {
+      return res.status(400).json({ error: "유효한 활동 정보를 입력해주세요." });
+    }
+
+    const user = await User.findById(req.user.id).select("activityHistory");
+    if (!user) {
+      return res.status(404).json({ error: "사용자를 찾을 수 없습니다." });
+    }
+
+    user.activityHistory.unshift(entry);
+    if (user.activityHistory.length > 50) {
+      user.activityHistory = user.activityHistory.slice(0, 50);
+    }
+    await user.save();
+
+    logger.info(`Activity added for ${req.user.username}: ${entry.title}`);
+    if (req.userLogger) {
+      req.userLogger("info", `활동 기록 추가: ${entry.title}`);
+    }
+
+    res.json({ message: "활동이 추가되었습니다.", activityHistory: user.activityHistory });
+  } catch (error) {
+    logger.error("Activity append failed", error);
+    res.status(500).json({ error: "활동을 추가하는 중 오류가 발생했습니다." });
+  }
+});
+
+router.get("/activity", authSimple, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id).select("activityHistory");
+    if (!user) {
+      return res.status(404).json({ error: "사용자를 찾을 수 없습니다." });
+    }
+
+    res.json(user.activityHistory || []);
+  } catch (error) {
+    logger.error("Activity fetch failed", error);
+    res.status(500).json({ error: "활동 내역을 불러오는 중 오류가 발생했습니다." });
+  }
+});
+
+router.get("/overview", authSimple, async (req, res) => {
+  try {
+    if (!mongoose.Types.ObjectId.isValid(req.user.id)) {
+      return res.status(400).json({ error: "유효하지 않은 사용자 ID입니다." });
+    }
+    const userObjectId = new mongoose.Types.ObjectId(req.user.id);
+    const [user, posts, comments, chats] = await Promise.all([
+      User.findById(req.user.id).select("-password").lean(),
+      Post.find({ author: req.user.id, deleted: { $ne: true } })
+        .sort({ time: -1 })
+        .limit(5)
+        .select("_id title time category")
+        .lean(),
+      Post.aggregate([
+        { $match: { deleted: { $ne: true } } },
+        { $unwind: "$comments" },
+        {
+          $match: {
+            "comments.author": userObjectId
+          }
+        },
+        { $sort: { "comments.time": -1 } },
+        { $limit: 5 },
+        {
+          $project: {
+            _id: "$comments._id",
+            content: "$comments.content",
+            time: "$comments.time",
+            postId: "$_id",
+            postTitle: "$title"
+          }
+        }
+      ]),
+      Message.find({ author: req.user.id })
+        .sort({ time: -1 })
+        .limit(10)
+        .select("room message messageType time")
+        .lean()
+    ]);
+
+    if (!user) {
+      return res.status(404).json({ error: "사용자를 찾을 수 없습니다." });
+    }
+
+    const activityHistory = Array.isArray(user.activityHistory)
+      ? [...user.activityHistory].sort((a, b) => new Date(b.occurredAt || 0) - new Date(a.occurredAt || 0)).slice(0, 20)
+      : [];
+
+    res.json({
+      profile: formatUserResponse(user),
+      recentPosts: posts,
+      recentComments: comments,
+      recentChats: chats,
+      activityHistory
+    });
+  } catch (error) {
+    logger.error("Profile overview failed", error);
+    res.status(500).json({ error: "프로필 정보를 불러오는 중 오류가 발생했습니다." });
+  }
+});
+
 router.get("/posts", authSimple, async (req, res) => {
   try {
     const posts = await Post.find({ author: req.user.id, deleted: { $ne: true } })
       .sort({ time: -1 })
-      // .select()에 '_id'를 추가하여 게시글 ID를 반드시 포함하도록 수정합니다.
-      .select('_id title time category') 
+      .select("_id title time category")
       .lean();
+
     res.json(posts);
-  } catch (err) {
-    console.error("Error fetching user posts:", err);
+  } catch (error) {
+    logger.error("Profile posts fetch failed", error);
     res.status(500).json({ error: "게시글을 불러오는 중 오류가 발생했습니다." });
   }
 });
 
-// 현재 로그인한 사용자가 작성한 댓글 목록 조회
 router.get("/comments", authSimple, async (req, res) => {
   try {
-    const mongoose = require('mongoose');
-    const userId = new mongoose.Types.ObjectId(req.user.id);
-
-    const myComments = await Post.aggregate([
+    if (!mongoose.Types.ObjectId.isValid(req.user.id)) {
+      return res.status(400).json({ error: "유효하지 않은 사용자 ID입니다." });
+    }
+    const userObjectId = new mongoose.Types.ObjectId(req.user.id);
+    const comments = await Post.aggregate([
+      { $match: { deleted: { $ne: true } } },
       { $unwind: "$comments" },
-      { $match: { "comments.author": userId, "deleted": { $ne: true } } },
+      {
+        $match: {
+          "comments.author": userObjectId
+        }
+      },
       { $sort: { "comments.time": -1 } },
+      { $limit: 20 },
       {
         $project: {
           _id: "$comments._id",
@@ -121,58 +431,110 @@ router.get("/comments", authSimple, async (req, res) => {
         }
       }
     ]);
-    res.json(myComments);
-  } catch (err) {
-    console.error("Error fetching user comments:", err);
+
+    res.json(comments);
+  } catch (error) {
+    logger.error("Profile comments fetch failed", error);
     res.status(500).json({ error: "댓글을 불러오는 중 오류가 발생했습니다." });
   }
 });
 
-// 사진 업로드 + 백업 (로그 추가)
-router.post("/photo", authSimple, upload.single("photo"), async (req,res)=>{
-  const me = await User.findById(req.user.id);
-  if(!me) return res.status(404).json({error:"사용자 없음"});
-  
-  // 새 파일 경로를 DB에 저장합니다.
-  me.photo = `/uploads/users/${req.file.filename}`;
-  await me.save();
-
-  // 백업 로직 (선택적)
-  const stamp = new Date().toISOString().replace(/[-:TZ.]/g,'').slice(0,14);
+router.post("/photo", authSimple, uploadAvatar.single("photo"), async (req, res) => {
   try {
-    fs.copyFileSync(
-      path.join(photoDir, req.file.filename),
-      path.join(backupDir, `${stamp}_${req.user.username}${path.extname(req.file.originalname)}`)
-    );
-  } catch{}
-  
-  const logger = require('../config/logger');
-  logger.info(`Profile photo updated: ${req.user.username} -> ${req.file.filename}`);
-  if (req.userLogger) req.userLogger('info', `프로필 사진 업로드: ${req.file.filename}`);
-  
-  res.json({ path: me.photo });
+    const user = await User.findById(req.user.id);
+    if (!user) {
+      return res.status(404).json({ error: "사용자를 찾을 수 없습니다." });
+    }
+
+    user.photo = `/uploads/users/${req.file.filename}`;
+    await user.save();
+
+    const stamp = new Date().toISOString().replace(/[-:TZ.]/g, "").slice(0, 14);
+    try {
+      fs.copyFileSync(
+        path.join(photoDir, req.file.filename),
+        path.join(backupDir, `${stamp}_${req.user.username}${path.extname(req.file.originalname)}`)
+      );
+    } catch (copyError) {
+      logger.warn("Profile photo backup failed", copyError);
+    }
+
+    logger.info(`Profile photo updated: ${req.user.username} -> ${req.file.filename}`);
+    if (req.userLogger) {
+      req.userLogger("info", `프로필 사진 업로드: ${req.file.filename}`);
+    }
+
+    res.json({ path: user.photo });
+  } catch (error) {
+    logger.error("Profile photo upload failed", error);
+    res.status(500).json({ error: "프로필 사진을 업데이트하는 중 오류가 발생했습니다." });
+  }
 });
 
-// 프로필 사진 삭제 API (로그 추가)
 router.delete("/photo", authSimple, async (req, res) => {
   try {
     const user = await User.findById(req.user.id);
     if (!user) {
       return res.status(404).json({ error: "사용자를 찾을 수 없습니다." });
     }
-    // DB에서 사진 경로 삭제
+
     user.photo = "";
     await user.save();
-    
-    const logger = require('../config/logger');
+
     logger.info(`Profile photo deleted: ${req.user.username}`);
-    if (req.userLogger) req.userLogger('info', `프로필 사진 삭제`);
-    
+    if (req.userLogger) {
+      req.userLogger("info", "프로필 사진 삭제");
+    }
+
     res.json({ message: "프로필 사진이 삭제되었습니다." });
-  } catch (err) {
+  } catch (error) {
+    logger.error("Profile photo delete failed", error);
     res.status(500).json({ error: "사진 삭제 중 오류가 발생했습니다." });
   }
 });
 
+router.post("/background", authSimple, uploadBackground.single("background"), async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id);
+    if (!user) {
+      return res.status(404).json({ error: "사용자를 찾을 수 없습니다." });
+    }
+
+    user.backgroundImage = `/uploads/users/backgrounds/${req.file.filename}`;
+    await user.save();
+
+    logger.info(`Profile background updated: ${req.user.username}`);
+    if (req.userLogger) {
+      req.userLogger("info", "프로필 배경 이미지 변경");
+    }
+
+    res.json({ path: user.backgroundImage });
+  } catch (error) {
+    logger.error("Profile background upload failed", error);
+    res.status(500).json({ error: "배경 이미지를 업데이트하는 중 오류가 발생했습니다." });
+  }
+});
+
+router.delete("/background", authSimple, async (req, res) => {
+  try {
+    const user = await User.findById(req.user.id);
+    if (!user) {
+      return res.status(404).json({ error: "사용자를 찾을 수 없습니다." });
+    }
+
+    user.backgroundImage = "";
+    await user.save();
+
+    logger.info(`Profile background deleted: ${req.user.username}`);
+    if (req.userLogger) {
+      req.userLogger("info", "프로필 배경 이미지 삭제");
+    }
+
+    res.json({ message: "배경 이미지가 삭제되었습니다." });
+  } catch (error) {
+    logger.error("Profile background delete failed", error);
+    res.status(500).json({ error: "배경 이미지를 삭제하는 중 오류가 발생했습니다." });
+  }
+});
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- extend the user model with profile appearance, badge, activity, and visibility metadata
- add profile API endpoints for overview aggregation, badge management, activity logging, and background uploads
- redesign the profile page UI and scripts to support editing media, badges, activity history, and privacy scopes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e64982d274832e93ee418383548f8b