### PR TITLE
Fix topbar widgets on profile page

### DIFF
--- a/public/profile.html
+++ b/public/profile.html
@@ -222,6 +222,11 @@
 
   <div id="toastRoot"></div>
 
+  <script src="/socket.io/socket.io.js"></script>
+  <script defer src="js/notifications.js"></script>
+  <script defer src="js/profile-menu.js"></script>
+  <script defer src="js/pwa.js"></script>
+  <script defer src="js/topbar-dock.js"></script>
   <script defer src="js/profile-page.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load the shared topbar scripts on the profile page so the notification and profile menus render and behave correctly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e656f29a04832ebc1dd716a36f2ed1