### PR TITLE
Fix calendar loading and topbar interactions

### DIFF
--- a/public/js/topbar-dock.js
+++ b/public/js/topbar-dock.js
@@ -1,5 +1,14 @@
 ﻿(() => {
-  const TARGET_IDS = ['notification-center', 'profile-menu-floating'];
+  const TARGETS = [
+    {
+      id: 'notification-center',
+      placeholderSelector: '[data-open-notifications]',
+    },
+    {
+      id: 'profile-menu-floating',
+      placeholderSelector: '[data-profile-menu]',
+    },
+  ];
 
   function ensureDock() {
     const header = document.querySelector('.site-topbar');
@@ -13,12 +22,37 @@
     return dock;
   }
 
+  function attachToPlaceholder(node, placeholder) {
+    if (!placeholder) return false;
+    if (placeholder === node || placeholder.contains(node)) return true;
+
+    if (placeholder.parentElement) {
+      placeholder.replaceWith(node);
+      return true;
+    }
+
+    return false;
+  }
+
   function moveFloatingNodes() {
     const dock = ensureDock();
     if (!dock) return;
-    TARGET_IDS.forEach((id) => {
+
+    TARGETS.forEach(({ id, placeholderSelector }) => {
       const node = document.getElementById(id);
-      if (node && node.parentElement !== dock) {
+      if (!node) return;
+
+      const placeholder = placeholderSelector
+        ? document.querySelector(placeholderSelector)
+        : null;
+
+      if (placeholder) {
+        if (attachToPlaceholder(node, placeholder)) {
+          return;
+        }
+      }
+
+      if (node.parentElement !== dock) {
         dock.appendChild(node);
       }
     });

--- a/routes/calendar.js
+++ b/routes/calendar.js
@@ -13,9 +13,6 @@ const CATEGORY_VALUES = Calendar.CATEGORY_VALUES;
 const PRIORITY_VALUES = Calendar.PRIORITY_VALUES;
 const NOTIFY_VALUES = Calendar.NOTIFY_VALUES;
 
-// 모든 일정 관련 API는 로그인 후 사용
-router.use(authenticateToken);
-
 function serializeReminderStatus(value) {
   if (!value) return {};
   if (typeof value.entries === 'function') {
@@ -187,7 +184,7 @@ function buildCommonFilters(query = {}) {
 /**
  * 일정 생성
  */
-router.post('/', async (req, res) => {
+router.post('/', authenticateToken, async (req, res) => {
   try {
     const { payload, errors } = validateCalendarPayload(req.body);
     if (errors.length) {
@@ -330,7 +327,7 @@ router.get('/:id', async (req, res) => {
 /**
  * 일정 수정 (작성자 전용)
  */
-router.put('/:id', async (req, res) => {
+router.put('/:id', authenticateToken, async (req, res) => {
   try {
     const calendar = await Calendar.findById(req.params.id).populate('createdBy', 'username name');
     if (!calendar || calendar.isDeleted) {
@@ -389,7 +386,7 @@ router.put('/:id', async (req, res) => {
 /**
  * 일정 삭제 (작성자 전용, 소프트 삭제)
  */
-router.delete('/:id', async (req, res) => {
+router.delete('/:id', authenticateToken, async (req, res) => {
   try {
     const calendar = await Calendar.findById(req.params.id);
     if (!calendar || calendar.isDeleted) {


### PR DESCRIPTION
## Summary
- allow calendar read endpoints to work without authentication while keeping create/update/delete guarded
- attach the floating notification and profile menus to their topbar placeholders so the buttons respond when clicked

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e6691bf008832ea89d6dfa053e309b