### PR TITLE
docs: refresh 설명서 based on repository layout

### DIFF
--- a/설명서.md
+++ b/설명서.md
@@ -1,6 +1,6 @@
 # 프로젝트 설명
 
-`my_server`는 Node.js(Express)와 MongoDB를 기반으로 하는 커뮤니티/업무용 웹 애플리케이션입니다. 사용자 인증, 게시판, 실시간 채팅, 알림, 관리자 콘솔 등을 제공하며 Socket.IO로 실시간 이벤트를 처리합니다. 정적 리소스는 `public/` 디렉터리에서 서빙되고, REST API는 `routes/` 하위 라우터로 구성됩니다.
+`my_server`는 Node.js(Express)와 MongoDB를 기반으로 하는 커뮤니티/업무용 웹 애플리케이션입니다. 사용자 인증, 게시판, 실시간 채팅, 알림, 관리자 콘솔 등을 제공하며 Socket.IO로 실시간 이벤트를 처리합니다. 정적 리소스는 `public/` 디렉터리에서 서빙되고, REST API는 `routes/` 하위 라우터로 구성됩니다. 추가로 공지/문의 대응 문서(`docs/`), 금칙어 검사용 ML 서비스(`ml/`), 폐기된 UI 시안(`폐기/`) 등이 레포지토리 루트에 공존합니다.
 
 ## 사전 준비
 - Node.js 18 LTS 이상과 npm
@@ -10,7 +10,7 @@
 
 ## 실행 방법
 1. 의존성 설치: `npm install`
-2. MongoDB 실행 후 `.env` 값 확인
+2. MongoDB 실행 후 환경 변수 파일(`.env` 또는 `.env.local`) 준비
 3. 개발 실행: `npx nodemon server.js` (또는 `npm start`)
 4. 브라우저 접속: `http://localhost:3000/`
    - 최초 `admin` 계정 로그인 시 자동으로 `superadmin` 권한 부여
@@ -38,27 +38,39 @@
 ## 폴더 구조 개요
 ```
 my_server/
-|-- server.js
-|-- .env
-|-- config/                # DB 연결, 로깅, 보안, 세션 설정
-|-- middleware/            # 인증, 콘텐츠 필터 등 공용 미들웨어
-|-- models/                # Mongoose 스키마
-|-- public/                # HTML/CSS/JS/폰트 자산
-|-- routes/                # REST API 라우터
-|-- services/              # 비즈니스 로직 서비스
-|-- scripts/               # 유지보수/마이그레이션 스크립트
-|-- utils/                 # 스케줄러 및 공용 유틸
-|-- uploads/               # 업로드 파일
-|-- logs/                  # 애플리케이션/사용자 로그
+|-- server.js                # Express 부트스트랩 + Socket.IO 초기화
+|-- config/                  # DB 연결, 보안/세션/환경 설정, 로거 정의
+|-- middleware/              # 인증, 콘텐츠 필터링 미들웨어
+|-- models/                  # 사용자/게시글/채팅/통계 등 Mongoose 스키마
+|-- routes/                  # auth, posts, chat, admin, calendar 등 REST 라우터
+|-- services/                # 알림, 계정 보안, 캘린더, 금칙어 분류 서비스
+|-- utils/                   # 스케줄러, 차단 로직, 로그 요약, 달력 백업
+|-- scripts/                 # 금칙어/백업/마이그레이션/인덱스 스크립트
+|-- public/                  # HTML, CSS, JS, 아이콘, 정적 업로드
+|   |-- css/                 # 공통/페이지별 스타일
+|   |-- js/                  # 프런트엔드 로직 (account, dashboard, polls 등)
+|   |-- uploads/             # 정적 샘플 업로드 파일
+|-- docs/                    # 보안, 문의, 알림센터 내부 문서
+|-- logs/                    # 애플리케이션/사용자 로그 디렉터리
+|-- ml/                      # KorCen 욕설/금칙어 분류 Python 서비스
+|-- uploads/                 # 런타임 업로드 저장소 (정적 public/uploads와 분리)
+|-- 폐기/                    # 미사용된 페이지 시안(학교 관련 HTML/JS)
+|-- package.json             # npm 스크립트 및 의존성
+|-- package-lock.json
+|-- README.md, 설명서.md
+|-- c…account-manager.js 등  # Windows 경로가 섞인 임시 백업 스크립트
 ```
+
+> **참고**: 루트에 존재하는 `cUsersHOME…` 형태의 파일은 Windows 환경에서 추출된 프런트엔드 자산 백업본입니다. 정식 자산은 `public/js/` 하위 파일을 사용하며, 백업본은 필요 시 비교/이전용으로만 참조합니다.
 
 ## 주요 파일 안내
 - `server.js`: Express 앱 초기화, Socket.IO 구성, 라우터/정적 자원 등록
 - `config/logger.js`, `config/userLogger.js`: 애플리케이션·사용자별 로그 설정
 - `middleware/auth.js`: JWT 인증, 세션 검사, 권한 체크
-- `routes/` 하위 라우터: `auth`, `users`, `posts`, `chat`, `admin`, `inquiry`, `setting`, `profile`, `notifications` 등
+- `routes/` 하위 라우터: `auth`, `users`, `posts`, `chat`, `admin`, `dashboard`, `calendar`, `polls`, `notifications`, `inquiry`, `report`, `setting`, `profile` 등
 - `services/notificationService.js`: 알림 생성/전송/멘션 탐지
-- `models/`: 사용자, 게시글, 채팅방, 메시지, 신고, 문의, 금칙어 등 도메인 모델
+- `services/korcenClassifier.js`, `ml/korcen_service.py`: 외부 Python 서비스와 연계해 금칙어/혐오 표현을 탐지
+- `models/`: 사용자, 게시글, 채팅방, 메시지, 신고, 문의, 금칙어, 통계, 캘린더 등 도메인 모델
 
 ## 운영 및 유지보수 팁
 - `logs/` 디렉터리에서 애플리케이션 및 사용자 활동을 추적하고 이슈 분석에 활용합니다.


### PR DESCRIPTION
## Summary
- expand the 설명서.md introduction with references to the docs, ml, and 폐기 directories present in the repository
- update the folder structure overview to describe the current layout of back-end, front-end, and auxiliary assets
- document additional routes and the korcen classification service based on the existing source files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e8cf6ae130832ebd2a73816d7f083c