### PR TITLE
Disable initial loading overlays on calendar and polls pages

### DIFF
--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -61,7 +61,7 @@
     state.month = Number.isNaN(month) ? now.getMonth() + 1 : month;
 
     bindEvents();
-    await loadEvents();
+    await loadEvents({ showLoading: false });
   }
 
   function bindEvents() {
@@ -124,8 +124,10 @@
     }
   }
 
-  async function loadEvents() {
-    showSpinner();
+  async function loadEvents({ showLoading = true } = {}) {
+    if (showLoading) {
+      showSpinner();
+    }
     try {
       const params = new URLSearchParams();
       params.set('year', state.year);
@@ -152,7 +154,9 @@
       console.error('[calendar] loadEvents', error);
       showToast(error.message || '일정 데이터를 불러오는 중 오류가 발생했습니다.');
     } finally {
-      hideSpinner();
+      if (showLoading) {
+        hideSpinner();
+      }
     }
   }
 

--- a/public/js/polls.js
+++ b/public/js/polls.js
@@ -50,7 +50,7 @@
 
     bindEvents();
     resetCreateForm();
-    await loadPolls();
+    await loadPolls({ silent: true });
   }
 
   function bindEvents() {


### PR DESCRIPTION
## Summary
- skip showing the calendar spinner during the initial page load
- load poll data without showing the blocking spinner on first render

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8e6be4090832e9c89f250e0f400f8