### PR TITLE
Remove calendar and poll loading overlays

### DIFF
--- a/public/js/calendar.js
+++ b/public/js/calendar.js
@@ -39,7 +39,6 @@
   const prevButton = document.querySelector('[data-prev-month]');
   const nextButton = document.querySelector('[data-next-month]');
   const todayButton = document.querySelector('[data-today]');
-  const spinner = document.querySelector('[data-spinner]');
   const toast = document.querySelector('[data-toast]');
   const modalBackdrop = document.querySelector('[data-modal-backdrop]');
   const modalContent = document.querySelector('[data-modal-content]');
@@ -125,7 +124,6 @@
   }
 
   async function loadEvents() {
-    showSpinner();
     try {
       const params = new URLSearchParams();
       params.set('year', state.year);
@@ -151,8 +149,6 @@
     } catch (error) {
       console.error('[calendar] loadEvents', error);
       showToast(error.message || '일정 데이터를 불러오는 중 오류가 발생했습니다.');
-    } finally {
-      hideSpinner();
     }
   }
 
@@ -421,7 +417,6 @@
 
   async function openDetailModal(eventId) {
     try {
-      showSpinner();
       const response = await requestWithTimeout(
         `${API_BASE}/${eventId}`,
         buildFetchOptions(),
@@ -434,8 +429,6 @@
     } catch (error) {
       console.error('[calendar] openDetailModal', error);
       showToast(error.message || '일정 상세 정보를 불러오는 중 오류가 발생했습니다.');
-    } finally {
-      hideSpinner();
     }
   }
 
@@ -580,7 +573,6 @@
       return;
     }
 
-    showSpinner();
     try {
       const eventId = form.dataset.eventId;
       const method = eventId ? 'PUT' : 'POST';
@@ -601,8 +593,6 @@
     } catch (error) {
       console.error('[calendar] handleSaveEvent', error);
       showToast(error.message || '일정을 저장하는 중 오류가 발생했습니다.');
-    } finally {
-      hideSpinner();
     }
   }
 
@@ -620,7 +610,6 @@
     const confirmed = window.confirm('정말로 일정을 삭제할까요?');
     if (!confirmed) return;
 
-    showSpinner();
     try {
       const response = await requestWithTimeout(
         `${API_BASE}/${eventId}`,
@@ -637,17 +626,7 @@
     } catch (error) {
       console.error('[calendar] handleDeleteEvent', error);
       showToast(error.message || '일정을 삭제하는 중 오류가 발생했습니다.');
-    } finally {
-      hideSpinner();
     }
-  }
-
-  function showSpinner() {
-    if (spinner) spinner.hidden = false;
-  }
-
-  function hideSpinner() {
-    if (spinner) spinner.hidden = true;
   }
 
   function showToast(message) {

--- a/public/js/polls.js
+++ b/public/js/polls.js
@@ -16,7 +16,6 @@
   const optionList = document.querySelector('[data-option-list]');
   const addOptionButton = document.querySelector('[data-add-option]');
   const toast = document.querySelector('[data-toast]');
-  const spinner = document.querySelector('[data-spinner]');
 
   const state = {
     token: null,
@@ -50,7 +49,7 @@
 
     bindEvents();
     resetCreateForm();
-    await loadPolls();
+    await loadPolls({ silent: true });
   }
 
   function bindEvents() {
@@ -79,9 +78,7 @@
   }
 
   async function loadPolls({ silent = false } = {}) {
-    if (!silent) {
-      setLoading(true);
-    }
+    
     try {
       const [activePayload, closedPayload] = await Promise.all([
         requestJSON(`${API_BASE}?status=active`),
@@ -95,10 +92,6 @@
     } catch (error) {
       console.error('[polls] load error', error);
       showToast(error.message || '투표 목록을 불러오지 못했습니다.');
-    } finally {
-      if (!silent) {
-        setLoading(false);
-      }
     }
   }
 
@@ -323,7 +316,6 @@
 
   async function handleVote(poll, form, status) {
     try {
-      setLoading(true);
       const selections = Array.from(form.querySelectorAll('input[type="radio"]:checked, input[type="checkbox"]:checked'))
         .map((input) => Number.parseInt(input.value, 10))
         .filter((value) => Number.isInteger(value));
@@ -349,8 +341,6 @@
     } catch (error) {
       console.error('[polls] vote error', error);
       showToast(error.message || '투표 처리 중 문제가 발생했습니다.');
-    } finally {
-      setLoading(false);
     }
   }
 
@@ -359,7 +349,6 @@
     if (!confirm('이 투표를 종료하시겠습니까? 종료 후에는 다시 열 수 없습니다.')) return;
 
     try {
-      setLoading(true);
       await requestJSON(`${API_BASE}/${pollId}/close`, { method: 'POST' });
       showToast('투표가 종료되었습니다.');
       await loadPolls({ silent: true });
@@ -367,8 +356,6 @@
     } catch (error) {
       console.error('[polls] close error', error);
       showToast(error.message || '투표를 종료하지 못했습니다.');
-    } finally {
-      setLoading(false);
     }
   }
 
@@ -415,7 +402,6 @@
     }
 
     try {
-      setLoading(true);
       await requestJSON(API_BASE, {
         method: 'POST',
         body: payload,
@@ -428,8 +414,6 @@
     } catch (error) {
       console.error('[polls] create error', error);
       showToast(error.message || '투표를 생성하지 못했습니다.');
-    } finally {
-      setLoading(false);
     }
   }
 
@@ -642,11 +626,6 @@
     if (!toast) return;
     toast.dataset.state = 'hidden';
     toast.hidden = true;
-  }
-
-  function setLoading(isLoading) {
-    if (!spinner) return;
-    spinner.hidden = !isLoading;
   }
 
   function formatDate(value) {


### PR DESCRIPTION
## Summary
- remove the calendar loading overlay so loading never shows during navigation or actions
- delete the polls page spinner logic so polls load and mutate without showing the overlay

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e8e6be4090832e9c89f250e0f400f8